### PR TITLE
fix(shop-detail.html): replace level 4 heading with level 2 heading

### DIFF
--- a/src/shop-detail.html
+++ b/src/shop-detail.html
@@ -182,7 +182,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           </shop-select>
         </div>
         <div class="description">
-          <h4>Description</h4>
+          <h2>Description</h2>
           <p id="desc"></p>
         </div>
         <shop-button responsive>

--- a/src/shop-detail.html
+++ b/src/shop-detail.html
@@ -77,8 +77,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         margin: 32px 0;
       }
 
-      .description > h4 {
+      .description > h2 {
         margin: 16px 0;
+        font-size: 13px;
       }
 
       .description > p {


### PR DESCRIPTION
Hi, on the item detail I propose to replace the level 4 heading of the description with a level 2 heading because there are no any other levels before except the level 1 for the item title.

Regards.