### PR TITLE
use blocking-elements

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "polymer": "polymer/polymer#^1.4.0",
-    "app-layout": "polymerelements/app-layout#^0.10.0",
+    "app-layout": "polymerelements/app-layout#blocking-elements",
     "app-route": "polymerelements/app-route#^0.9.1",
     "iron-flex-layout": "polymerelements/iron-flex-layout#^1.0.0",
     "iron-form": "polymerelements/iron-form#^1.0.0",
@@ -15,11 +15,13 @@
     "iron-iconset-svg": "polymerelements/iron-iconset-svg#^1.0.0",
     "iron-localstorage": "polymerelements/iron-localstorage#^1.0.0",
     "iron-media-query": "polymerelements/iron-media-query#^1.0.0",
-    "iron-overlay-behavior": "polymerelements/iron-overlay-behavior#^1.0.0",
+    "iron-overlay-behavior": "polymerelements/iron-overlay-behavior#blocking-elements",
     "iron-pages": "polymerelements/iron-pages#^1.0.0",
     "iron-selector": "polymerelements/iron-selector#^1.0.0",
     "paper-icon-button": "polymerelements/paper-icon-button#^1.0.0",
-    "paper-spinner": "polymerelements/paper-spinner#^1.0.0"
+    "paper-spinner": "polymerelements/paper-spinner#^1.0.0",
+    "blockingElements": "PolymerLabs/blockingElements#issue-2",
+    "inert": "WICG/inert"
   },
   "devDependencies": {
     "web-component-tester": "^4.0.0"

--- a/index.html
+++ b/index.html
@@ -73,5 +73,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     })();
   </script>
 
+  <script src="/bower_components/blockingElements/blocking-elements.js"></script>
+  <script src="/bower_components/inert/inert.js"></script>
+
 </body>
 </html>


### PR DESCRIPTION
DO NOT MERGE

Experiment with [`blockingElements`](https://github.com/PolymerLabs/blockingElements) and [`inert`](https://github.com/WICG/inert/) polyfills to take care of focus wrapping.
Using `app-drawer`from https://github.com/PolymerElements/app-layout/pull/327

`app-drawer` has `tabindex=0` which results in an extra Tab needed to wrap the focus. Removing it has the drawback of always focusing the first focusable when `app-drawer` is opened.

@frankiefu FYI, PTAL

 