### PR TITLE
Add correct target directory for bower files during `bower install`

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory" : "bower_components"
+}

--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,4 @@
+
 {
   "directory" : "bower_components"
 }


### PR DESCRIPTION
Not sure why this is not already in the default app, or is it because of my local bower configs? 

Anyway, in the default app, `bower install` installs into `client/bower_components` which fails to run the app during `polymer serve`. So I just created a .bowerrc to make it install into the root folder's `bower_components`.