### PR TITLE
Make possessive gender labels consistent

### DIFF
--- a/data/ladies_outerwear.json
+++ b/data/ladies_outerwear.json
@@ -1,7 +1,7 @@
 [
   {
     "name":"Ladies+Modern+Stretch+Full+Zip",
-    "title":"Ladies Modern Stretch Full Zip",
+    "title":"Ladies' Modern Stretch Full Zip",
     "category":"ladies_outerwear",
     "price":41.60,
     "description":"With an updated fit and figure-flattering details, this full-zip combines ultra soft cotton with a dash of spandex to retain its shape all day long.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;96% cotton, 4% spandex.&lt;/li&gt;&lt;li&gt;Gently contoured silhouette &amp;amp; longer length design for a style that moves with you.&lt;/li&gt;&lt;li&gt;Self-fabric hood.&lt;/li&gt;&lt;li&gt;Dyed-to-match zipper.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Front slash pockets.&lt;/li&gt;&lt;li&gt;Open cuffs &amp;amp; hem.&lt;/li&gt;&lt;li&gt;Available in Mosaic Blue with the white Google logo embroidered at left chest.&amp;nbsp;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
@@ -10,7 +10,7 @@
   },
   {
     "name":"Ladies+Colorblock+Wind+Jacket",
-    "title":"Ladies Colorblock Wind Jacket",
+    "title":"Ladies' Colorblock Wind Jacket",
     "category":"ladies_outerwear",
     "price":45.90,
     "description":"Brighten up your commute on gloomy days. This lightweight jacket features a subtle grid texture and a punch of bright pink at each side panel.&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% polyester dobby shell with jersey lining.&lt;/li&gt;&lt;li&gt;Packable zip-in hood with contrast pink zipper.&lt;/li&gt;&lt;li&gt;Cadet collar and elastic cuffs.&lt;/li&gt;&lt;li&gt;Adjustable toggles at waist can be cinched for a flattering fit.&lt;/li&gt;&lt;li&gt;Available in grey/dark rose with the white Google logo embroidered at left chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
@@ -19,7 +19,7 @@
   },
   {
     "name":"Ladies+Voyage+Fleece+Jacket",
-    "title":"Ladies Voyage Fleece Jacket",
+    "title":"Ladies' Voyage Fleece Jacket",
     "category":"ladies_outerwear",
     "price":48.00,
     "description":"&lt;div&gt;Perhaps the equivalent to that comfort blanket you had years ago is a cozy fleece. This full-zip is the perfect layering piece for those 'in-between' months when mother nature just can't make up her mind.&amp;nbsp;&lt;/div&gt;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% polyester anti-pill yarn fleece.&lt;/li&gt;&lt;li&gt;100% polyester taffeta lining in sleeves.&lt;/li&gt;&lt;li&gt;Tricot-lined lower pockets with reverse coil zippers.&lt;/li&gt;&lt;li&gt;Available in purple with the white Google logo embroidered at left chest.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Please note! Sizing runs larger than normal. Consider ordering a size smaller than normal.&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
@@ -28,7 +28,7 @@
   },
   {
     "name":"Ladies+Pullover+L+S+Hood",
-    "title":"Ladies Pullover L/S Hood",
+    "title":"Ladies' Pullover L/S Hood",
     "category":"ladies_outerwear",
     "price":36.50,
     "description":"A longsleeve layering piece with a hood. What more can you ask for between season changes?&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;85% polyester, 15% cotton.&lt;/li&gt;&lt;li&gt;Ultra lightweight, tissue jersey fabric.&lt;/li&gt;&lt;li&gt;Scoop-neck with hood.&lt;/li&gt;&lt;li&gt;Available in jewel blue with the white Google logo screenprinted across center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
@@ -37,7 +37,7 @@
   },
   {
     "name":"Ladies+Sonoma+Hybrid+Knit+Jacket",
-    "title":"Ladies Sonoma Hybrid Knit Jacket",
+    "title":"Ladies' Sonoma Hybrid Knit Jacket",
     "category":"ladies_outerwear",
     "price":84.85,
     "description":"A modern styled sport jacket that combines a classic silhouette with moisture-wicking fabrics. Technical features include a reversed coil zipper with reflective stripe, interior media exit port, and built-in media pocket.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Additional Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;94% polyester, 6% spandex.&lt;/li&gt;&lt;li&gt;Available in black with the white Google logo heat transferred onto right hip along zipper.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
@@ -46,7 +46,7 @@
   },
   {
     "name":"Ladies+Yerba+Knit+Quarter+Zip",
-    "title":"Ladies Yerba Knit Quarter Zip",
+    "title":"Ladies' Yerba Knit Quarter Zip",
     "category":"ladies_outerwear",
     "price":64.20,
     "description":"This on-trend quarter zip doubles as workout gear.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;81% polyester, 19% spandex jersey knit.&lt;/li&gt;&lt;li&gt;Textured knit fabric features a moisture-wicking finish.&lt;/li&gt;&lt;li&gt;Exposed contrast reverse coil zipper with contrast inner collar.&lt;/li&gt;&lt;li&gt;Lightweight design with added stretch.&lt;/li&gt;&lt;li&gt;Available in heathered indigo with the white Google logo heat transferred vertically onto front right hip.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",

--- a/data/ladies_tshirts.json
+++ b/data/ladies_tshirts.json
@@ -1,7 +1,7 @@
 [
   {
     "name":"Ladies+Chrome+T-Shirt",
-    "title":"Ladies Chrome T-Shirt",
+    "title":"Ladies' Chrome T-Shirt",
     "category":"ladies_tshirts",
     "price":13.30,
     "description":"The best of three fabrics combined into one seductively-soft tee.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;50% polyester, 25% combed and ring-spun cotton, 25% rayon.&lt;/li&gt;&lt;li&gt;Side-seamed.&lt;/li&gt;&lt;li&gt;Semi-relaxed fit.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Available in heather blue with the white Google Chrome logo screenprinted at center chest.&amp;nbsp;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
@@ -10,7 +10,7 @@
   },
   {
     "name":"Ladies+Google+New+York+T-Shirt",
-    "title":"Ladies Google New York T-Shirt",
+    "title":"Ladies' Google New York T-Shirt",
     "category":"ladies_tshirts",
     "price":18.35,
     "description":"Are you feeling lucky? Inspired by city lights in The Big Apple, this tee features the 'I'm Feeling Lucky New York' phrase at back.&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% cotton.&lt;/li&gt;&lt;li&gt;American Apparel shirt designed with a ladies fit in mind.&lt;/li&gt;&lt;li&gt;Available in Black with the Google logo and 'I'm Feeling Lucky' New York printed on back yoke in White.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Sizing runs smaller than normal. Please reference size chart before ordering.&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
@@ -19,7 +19,7 @@
   },
   {
     "name":"Ladies+Gmail+T-Shirt",
-    "title":"Ladies Gmail T-Shirt",
+    "title":"Ladies' Gmail T-Shirt",
     "category":"ladies_tshirts",
     "price":16.40,
     "description":"Show your inbox some love. The new Gmail tee has arrived, complete with a subtle Mvelope design that showcases all of the Gmail icons you use on the daily.&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;50% polyester, 25% cotton.&lt;/li&gt;&lt;li&gt;Bella+Canvas.&lt;/li&gt;&lt;li&gt;Available in vintage red with the new Gmail print screenprinted across center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
@@ -28,7 +28,7 @@
   },
   {
     "name":"Ladies+G+Logo+White+T-Shirt",
-    "title":"Ladies G Logo White T-Shirt",
+    "title":"Ladies' G Logo White T-Shirt",
     "category":"ladies_tshirts",
     "price":13.30,
     "description":"There's a new G in town and it's here to stay. Get your hands on this comfy white tee with the new Google icon.&amp;nbsp;\n\n&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&amp;nbsp;&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% combed and ring-spun cotton.&lt;/li&gt;&lt;li&gt;Side seamed, relaxed fit.&lt;/li&gt;&lt;li&gt;Bella+Canvas.&lt;/li&gt;&lt;li&gt;Available in white with the Google 'G' icon screenprinted at front.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
@@ -37,7 +37,7 @@
   },
   {
     "name":"Ladies+Android+Pride+T-Shirt",
-    "title":"Ladies Android Pride T-Shirt",
+    "title":"Ladies' Android Pride T-Shirt",
     "category":"ladies_tshirts",
     "price":19.10,
     "description":"Stand out proud in this Ladies' Android Pride T-shirt.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% cotton.&lt;/li&gt;&lt;li&gt;Available in black and features two Androids holding hands and waving a rainbow flag printed across the front. Google logo screen printed in white on the sleeve.&amp;nbsp;&lt;/li&gt;&lt;li&gt;&lt;b&gt;Sizing runs smaller than normal. Please reference size chart before ordering.&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
@@ -46,7 +46,7 @@
   },
   {
     "name":"Ladies+Ringspun+Crew+Neck",
-    "title":"Ladies Ringspun Crew Neck",
+    "title":"Ladies' Ringspun Crew Neck",
     "category":"ladies_tshirts",
     "price":19.70,
     "description":"Cheery colors make the world a happier place. This bright pink tee is ultra soft and features a comfortable, ladies fit.&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% cotton.&lt;/li&gt;&lt;li&gt;Tagless label for added comfort.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Relaxed fit.&lt;/b&gt;&lt;/li&gt;&lt;li&gt;Available in hot pink with the white Google logo screenprinted at center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
@@ -55,7 +55,7 @@
   },
   {
     "name":"Ladies+Tri-Blend+V-Neck+T-Shirt",
-    "title":"Ladies Tri-Blend V-Neck T-Shirt",
+    "title":"Ladies' Tri-Blend V-Neck T-Shirt",
     "category":"ladies_tshirts",
     "price":35.10,
     "description":"A tagless label, ultra soft triblend fabric and v-neck cut are three ingredients for a favorite tee.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;25% cotton, 50% polyester, 25% rayon.&lt;/li&gt;&lt;li&gt;Made in California.&lt;/li&gt;&lt;li&gt;Available in green with the white Google logo screenprinted at center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
@@ -64,7 +64,7 @@
   },
   {
     "name":"Bella+Ladies+Favorite+Tee",
-    "title":"Bella Ladies Favorite Tee",
+    "title":"Bella Ladies' Favorite Tee",
     "category":"ladies_tshirts",
     "price":10.50,
     "description":"This ladies tee features a longer body length perfect for layering up.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% combed, ringspun cotton.&lt;/li&gt;&lt;li&gt;Extra soft, lightweight fabric.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Slim fit. Runs small.&amp;nbsp;&lt;/b&gt;&lt;/li&gt;&lt;li&gt;Available in aqua with the white Google logo screenprinted at center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
@@ -73,7 +73,7 @@
   },
   {
     "name":"Ladies+Bamboo+T-Shirt",
-    "title":"Ladies Bamboo T-Shirt",
+    "title":"Ladies' Bamboo T-Shirt",
     "category":"ladies_tshirts",
     "price":20.65,
     "description":"A bamboo tee that's softer than your favorite cotton t-shirt. Your skin will thank you during those long nights of programming.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;70% viscose from organic bamboo, 30% organic cotton.&lt;/li&gt;&lt;li&gt;Available in vintage pink with the white Google logo screen printed at center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
@@ -82,7 +82,7 @@
   },
   {
     "name":"Ladies+L+S+Colorblock+Raglan",
-    "title":"Ladies L/S Colorblock Raglan",
+    "title":"Ladies' L/S Colorblock Raglan",
     "category":"ladies_tshirts",
     "price":36.95,
     "description":"Add a dose of mango to your t-shirt lineup. This scoop neck raglan features a bright pop of color and a scoop neck with v-notch.&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;60% cotton, 40% polyester.&lt;/li&gt;&lt;li&gt;Scoop hem.&lt;/li&gt;&lt;li&gt;Self-fabric cuff bands.&lt;/li&gt;&lt;li&gt;Available in heather/mango with the white Google logo screenprinted at center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
@@ -91,7 +91,7 @@
   },
   {
     "name":"Bella+Scoop-Neck+Ladies+T-Shirt",
-    "title":"Bella Scoop-Neck Ladies T-Shirt",
+    "title":"Bella Scoop-Neck Ladies' T-Shirt",
     "category":"ladies_tshirts",
     "price":13.10,
     "description":"A classic that's here to stay is this ladies white baby ribbed tee. Features a feminine scoop cut at the neck and 1x1 baby rib texture. Available in white with the full color Google logo screen printed at center chest.",
@@ -100,7 +100,7 @@
   },
   {
     "name":"Ladies+Not+For+Sale+T-Shirt",
-    "title":"Ladies Not For Sale T-Shirt",
+    "title":"Ladies' Not For Sale T-Shirt",
     "category":"ladies_tshirts",
     "price":24.00,
     "description":"This Not for Sale t-shirt features just the right amount of 'V' around the neck with the Google logo placed perfectly underneath. Not for Sale focuses efforts on growing social enterprises to benefit those enslaved and vulnerable communities around the world.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;Available in black with the Google logo imprinted in white across upper chest.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Sizing runs smaller than normal. Please consider ordering up one or two sizes.&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
@@ -109,7 +109,7 @@
   },
   {
     "name":"Ladies+Android+L+S+Stretch+T-Shirt",
-    "title":"Ladies Android L/S Stretch T-Shirt",
+    "title":"Ladies' Android L/S Stretch T-Shirt",
     "category":"ladies_tshirts",
     "price":20.00,
     "description":"Sparkle and shine in this ladies long sleeve stretch tee.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features;&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;95% premium, ring-spun cotton, 5% spandex.&lt;/li&gt;&lt;li&gt;Available in Black with a glitter Android robot at left chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
@@ -118,7 +118,7 @@
   },
   {
     "name":"Ladies+Mountain+View+T-Shirt",
-    "title":"Ladies Mountain View T-Shirt",
+    "title":"Ladies' Mountain View T-Shirt",
     "category":"ladies_tshirts",
     "price":17.50,
     "description":"The Bay Area city named for its beautiful views of the Santa Cruz Mountains is also home to the Googleplex located at 1600 Amphitheater Parkway. Celebrate the place Google calls home in this ladies scoop neck tee.&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% cotton.&lt;/li&gt;&lt;li&gt;Available in white with the Mountain View coordinates screenprinted at front and the full color Google logo screenprinted at back yoke.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
@@ -127,7 +127,7 @@
   },
   {
     "name":"Ladies+Blueprint+for+a+Better+Inbox+T-Shirt",
-    "title":"Ladies Blueprint for a Better Inbox T-Shirt",
+    "title":"Ladies' Blueprint for a Better Inbox T-Shirt",
     "category":"ladies_tshirts",
     "price":14.30,
     "description":"The \"Blueprint for  better Inbox\" now available for the ladies! This USA made American Apparel t-shirt sports a more fitted design and &amp;nbsp;the new Inbox logo.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Additional Features:&amp;nbsp;&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;50% cotton / 50% polyester for a super soft fit.&lt;/li&gt;&lt;li&gt;Available in royal blue heather with the \"New Inbox: logo screen printed on the center chest.&amp;nbsp;&lt;/li&gt;&lt;li&gt;&lt;b&gt;Sizing runs smaller than normal. Please reference sizing chart prior to ordering.&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
@@ -136,7 +136,7 @@
   },
   {
     "name":"Ladies+Cotton+Poly+w++Thermal+Tee",
-    "title":"Ladies Cotton Poly w/ Thermal Tee",
+    "title":"Ladies' Cotton Poly w/ Thermal Tee",
     "category":"ladies_tshirts",
     "price":15.15,
     "description":"This thermal long sleeve t-shirt is lightweight enough for all seasons of the year.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;60% cotton, 40% polyester.&lt;/li&gt;&lt;li&gt;Wide boat neck, thermal sleeves and hight length thermal cuffs.&lt;/li&gt;&lt;li&gt;Longer body for comfortable fit.&lt;/li&gt;&lt;li&gt;Available in blue/black with the white Google logo screenprinted at center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
@@ -145,7 +145,7 @@
   },
   {
     "name":"Ladies+YouTube+Favorite+Tee",
-    "title":"Ladies YouTube Favorite Tee",
+    "title":"Ladies' YouTube Favorite Tee",
     "category":"ladies_tshirts",
     "price":11.10,
     "description":"It's called the 'favorite tee' for a reason. Designed with fashion and comfort in mind, this ladies tee is ultra soft and provides a great fit, every time.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% combed, ring-spun cotton.&lt;/li&gt;&lt;li&gt;Designed with a longer length for varying body types.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Available in asphalt with the full color YouTube logo screen printed across center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
@@ -154,7 +154,7 @@
   },
   {
     "name":"MTV+Ladies+Yellow+T-Shirt",
-    "title":"MTV Ladies Yellow T-Shirt",
+    "title":"MTV Ladies' Yellow T-Shirt",
     "category":"ladies_tshirts",
     "price":16.90,
     "description":"They say home is where the heart is. This vibrant tee features the Bay Area address of Google's head office. &amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% combed cotton.&lt;/li&gt;&lt;li&gt;Made in the USA.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Available in gold with a striking design at front and the white Google logo at back yoke.&amp;nbsp;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",

--- a/data/mens_outerwear.json
+++ b/data/mens_outerwear.json
@@ -1,6 +1,6 @@
 [
   {
-    "name":"Men+s+Tech+Shell+Full-Zip",
+    "name":"Mens+Tech+Shell+Full-Zip",
     "title":"Men's Tech Shell Full-Zip",
     "category":"mens_outerwear",
     "price":50.20,
@@ -81,7 +81,7 @@
     "largeImage":"/data/images/10-14152A.jpg"
   },
   {
-    "name":"Men+s+Voyage+Fleece+Jacket",
+    "name":"Mens+Voyage+Fleece+Jacket",
     "title":"Men's Voyage Fleece Jacket",
     "category":"mens_outerwear",
     "price":48.00,

--- a/data/mens_tshirts.json
+++ b/data/mens_tshirts.json
@@ -27,7 +27,7 @@
     "largeImage":"/data/images/10-13239A.jpg"
   },
   {
-    "name":"Men+s+Vintage+Heather+T-Shirt",
+    "name":"Mens+Vintage+Heather+T-Shirt",
     "title":"Men's Vintage Heather T-Shirt",
     "category":"mens_tshirts",
     "price":15.8,
@@ -144,7 +144,7 @@
     "largeImage":"/data/images/10-13276A.jpg"
   },
   {
-    "name":"Tri-Blend+G+Logo+Men+s+Polo",
+    "name":"Tri-Blend+G+Logo+Mens+Polo",
     "title":"Tri-Blend G Logo Men's Polo",
     "category":"mens_tshirts",
     "price":32.7,
@@ -315,7 +315,7 @@
     "largeImage":"/data/images/10-13130A.jpg"
   },
   {
-    "name":"Men+s+Bamboo+T-Shirt",
+    "name":"Mens+Bamboo+T-Shirt",
     "title":"Men's Bamboo T-Shirt",
     "category":"mens_tshirts",
     "price":20.65,


### PR DESCRIPTION
It previously showed "Men's" and "Ladies".  I added an apostrophe to the end of Ladies to make it consistent.

Incidentally, retailers (e.g. Macy's, Nordstrom) use the phrase "Women's" as the feminine equivalent of "Men's".  Is there a reason Shop uses "Ladies'"?