### PR TITLE
Fix bad behavior reference in shop-cart-modal

### DIFF
--- a/src/shop-cart-modal.html
+++ b/src/shop-cart-modal.html
@@ -111,7 +111,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       is: 'shop-cart-modal',
 
       behaviors: [
-        Polymer.IronOverlayBehaviorImpl
+        Polymer.IronOverlayBehavior
       ],
 
       properties: {


### PR DESCRIPTION
The new analyzer caught a bug here, where shop-cart-modal is referencing `IronOverlayBehaviorImpl` instead of `IronOverlayBehavior`. See https://github.com/PolymerElements/iron-overlay-behavior/blob/master/iron-overlay-behavior.html for their definitions.

/cc @keanulee I think? Feel free to reassign