### PR TITLE
Debounce 404 page to ensure properties have been updated

### DIFF
--- a/src/shop-category-data.html
+++ b/src/shop-category-data.html
@@ -66,7 +66,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         item: {
           type: Object,
-          computed: '_computeItem(category.items, itemName)',
+          readOnly: true,
           notify: true
         },
 
@@ -76,6 +76,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           readOnly: true
         }
       },
+
+      observers: [
+        '_computeItem(category.items, itemName)'
+      ],
 
       _getCategoryObject: function(categoryName) {
         for (var i = 0, c; c = this.categories[i]; ++i) {
@@ -96,12 +100,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _computeItem: function(items, itemName) {
-        for (var i = 0, item; item = items[i]; ++i) {
-          if (item.name === itemName) {
-            return item;
+        // items and itemName are updated from the route. Since they are
+        // updated sequentially and not once, there will be 1 cycle where
+        // itemName does not exist in the items array.
+        // Therefore we have to debounce the calculation 1 frame to make
+        // sure both values have been properly updated.
+        this.debounce('compute-item', function() {
+          for (var i = 0, item; item = items[i]; ++i) {
+            if (item.name === itemName) {
+              this.item !== item && this._setItem(item);
+              return;
+            }
           }
-        }
-        this.fire('show-invalid-url-warning');
+          this.fire('show-invalid-url-warning');
+        });
       },
 
       _fetchItems: function(category, attempts) {

--- a/src/shop-detail.html
+++ b/src/shop-detail.html
@@ -248,7 +248,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               category: item.category,
               title: item.title
             });
-          });
+            // Debounce for 2 frames to  make sure that `shop-category-data` has updated
+            // its internal item before trying to change the item.
+          },2);
         }
       },
 


### PR DESCRIPTION
This was a tricky one. The bug boiled down to `app-route` updating the route segments one at a time. Since bindings are updated sequentially, at first `routeData.category` would be updated and after all observers etc... were finished, `routeData.item` would be updated. In consequence, there is 1 moment of inconsistency in the data, since the `category` was updated, but the corresponding `item` was not.

To fix this, the actual item retrieval must be debounced 1 frame to make sure both bindings are updated and only then the item has to be computed.

There was a visual regression when switching tabs in `shop-detail` where it thought that the item was updated too early. E.g. the binding of visible was updated, but since `item` was debounced it was not ready yet. Therefore that debounce has to run after 2 frames.

Fixes #100