### PR TITLE
Updates for differential serving.

### DIFF
--- a/data/ladies_outerwear.json
+++ b/data/ladies_outerwear.json
@@ -5,8 +5,8 @@
     "category":"ladies_outerwear",
     "price":41.60,
     "description":"With an updated fit and figure-flattering details, this full-zip combines ultra soft cotton with a dash of spandex to retain its shape all day long.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;96% cotton, 4% spandex.&lt;/li&gt;&lt;li&gt;Gently contoured silhouette &amp;amp; longer length design for a style that moves with you.&lt;/li&gt;&lt;li&gt;Self-fabric hood.&lt;/li&gt;&lt;li&gt;Dyed-to-match zipper.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Front slash pockets.&lt;/li&gt;&lt;li&gt;Open cuffs &amp;amp; hem.&lt;/li&gt;&lt;li&gt;Available in Mosaic Blue with the white Google logo embroidered at left chest.&amp;nbsp;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-24102B.jpg",
-    "largeImage":"/data/images/10-24102A.jpg"
+    "image":"data/images/10-24102B.jpg",
+    "largeImage":"data/images/10-24102A.jpg"
   },
   {
     "name":"Ladies+Colorblock+Wind+Jacket",
@@ -14,8 +14,8 @@
     "category":"ladies_outerwear",
     "price":45.90,
     "description":"Brighten up your commute on gloomy days. This lightweight jacket features a subtle grid texture and a punch of bright pink at each side panel.&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% polyester dobby shell with jersey lining.&lt;/li&gt;&lt;li&gt;Packable zip-in hood with contrast pink zipper.&lt;/li&gt;&lt;li&gt;Cadet collar and elastic cuffs.&lt;/li&gt;&lt;li&gt;Adjustable toggles at waist can be cinched for a flattering fit.&lt;/li&gt;&lt;li&gt;Available in grey/dark rose with the white Google logo embroidered at left chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-25058B.jpg",
-    "largeImage":"/data/images/10-25058A.jpg"
+    "image":"data/images/10-25058B.jpg",
+    "largeImage":"data/images/10-25058A.jpg"
   },
   {
     "name":"Ladies+Voyage+Fleece+Jacket",
@@ -23,8 +23,8 @@
     "category":"ladies_outerwear",
     "price":48.00,
     "description":"&lt;div&gt;Perhaps the equivalent to that comfort blanket you had years ago is a cozy fleece. This full-zip is the perfect layering piece for those 'in-between' months when mother nature just can't make up her mind.&amp;nbsp;&lt;/div&gt;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% polyester anti-pill yarn fleece.&lt;/li&gt;&lt;li&gt;100% polyester taffeta lining in sleeves.&lt;/li&gt;&lt;li&gt;Tricot-lined lower pockets with reverse coil zippers.&lt;/li&gt;&lt;li&gt;Available in purple with the white Google logo embroidered at left chest.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Please note! Sizing runs larger than normal. Consider ordering a size smaller than normal.&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-24101B.jpg",
-    "largeImage":"/data/images/10-24101A.jpg"
+    "image":"data/images/10-24101B.jpg",
+    "largeImage":"data/images/10-24101A.jpg"
   },
   {
     "name":"Ladies+Pullover+L+S+Hood",
@@ -32,8 +32,8 @@
     "category":"ladies_outerwear",
     "price":36.50,
     "description":"A longsleeve layering piece with a hood. What more can you ask for between season changes?&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;85% polyester, 15% cotton.&lt;/li&gt;&lt;li&gt;Ultra lightweight, tissue jersey fabric.&lt;/li&gt;&lt;li&gt;Scoop-neck with hood.&lt;/li&gt;&lt;li&gt;Available in jewel blue with the white Google logo screenprinted across center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-24098B.jpg",
-    "largeImage":"/data/images/10-24098A.jpg"
+    "image":"data/images/10-24098B.jpg",
+    "largeImage":"data/images/10-24098A.jpg"
   },
   {
     "name":"Ladies+Sonoma+Hybrid+Knit+Jacket",
@@ -41,8 +41,8 @@
     "category":"ladies_outerwear",
     "price":84.85,
     "description":"A modern styled sport jacket that combines a classic silhouette with moisture-wicking fabrics. Technical features include a reversed coil zipper with reflective stripe, interior media exit port, and built-in media pocket.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Additional Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;94% polyester, 6% spandex.&lt;/li&gt;&lt;li&gt;Available in black with the white Google logo heat transferred onto right hip along zipper.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-24097B.jpg",
-    "largeImage":"/data/images/10-24097A.jpg"
+    "image":"data/images/10-24097B.jpg",
+    "largeImage":"data/images/10-24097A.jpg"
   },
   {
     "name":"Ladies+Yerba+Knit+Quarter+Zip",
@@ -50,7 +50,7 @@
     "category":"ladies_outerwear",
     "price":64.20,
     "description":"This on-trend quarter zip doubles as workout gear.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;81% polyester, 19% spandex jersey knit.&lt;/li&gt;&lt;li&gt;Textured knit fabric features a moisture-wicking finish.&lt;/li&gt;&lt;li&gt;Exposed contrast reverse coil zipper with contrast inner collar.&lt;/li&gt;&lt;li&gt;Lightweight design with added stretch.&lt;/li&gt;&lt;li&gt;Available in heathered indigo with the white Google logo heat transferred vertically onto front right hip.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-24099B.jpg",
-    "largeImage":"/data/images/10-24099A.jpg"
+    "image":"data/images/10-24099B.jpg",
+    "largeImage":"data/images/10-24099A.jpg"
   }
 ]

--- a/data/ladies_tshirts.json
+++ b/data/ladies_tshirts.json
@@ -5,8 +5,8 @@
     "category":"ladies_tshirts",
     "price":13.30,
     "description":"The best of three fabrics combined into one seductively-soft tee.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;50% polyester, 25% combed and ring-spun cotton, 25% rayon.&lt;/li&gt;&lt;li&gt;Side-seamed.&lt;/li&gt;&lt;li&gt;Semi-relaxed fit.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Available in heather blue with the white Google Chrome logo screenprinted at center chest.&amp;nbsp;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-23180B.jpg",
-    "largeImage":"/data/images/10-23180A.jpg"
+    "image":"data/images/10-23180B.jpg",
+    "largeImage":"data/images/10-23180A.jpg"
   },
   {
     "name":"Ladies+Google+New+York+T-Shirt",
@@ -14,8 +14,8 @@
     "category":"ladies_tshirts",
     "price":18.35,
     "description":"Are you feeling lucky? Inspired by city lights in The Big Apple, this tee features the 'I'm Feeling Lucky New York' phrase at back.&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% cotton.&lt;/li&gt;&lt;li&gt;American Apparel shirt designed with a ladies fit in mind.&lt;/li&gt;&lt;li&gt;Available in Black with the Google logo and 'I'm Feeling Lucky' New York printed on back yoke in White.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Sizing runs smaller than normal. Please reference size chart before ordering.&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-23226B.jpg",
-    "largeImage":"/data/images/10-23226A.jpg"
+    "image":"data/images/10-23226B.jpg",
+    "largeImage":"data/images/10-23226A.jpg"
   },
   {
     "name":"Ladies+Gmail+T-Shirt",
@@ -23,8 +23,8 @@
     "category":"ladies_tshirts",
     "price":16.40,
     "description":"Show your inbox some love. The new Gmail tee has arrived, complete with a subtle Mvelope design that showcases all of the Gmail icons you use on the daily.&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;50% polyester, 25% cotton.&lt;/li&gt;&lt;li&gt;Bella+Canvas.&lt;/li&gt;&lt;li&gt;Available in vintage red with the new Gmail print screenprinted across center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-23179B.jpg",
-    "largeImage":"/data/images/10-23179A.jpg"
+    "image":"data/images/10-23179B.jpg",
+    "largeImage":"data/images/10-23179A.jpg"
   },
   {
     "name":"Ladies+G+Logo+White+T-Shirt",
@@ -32,8 +32,8 @@
     "category":"ladies_tshirts",
     "price":13.30,
     "description":"There's a new G in town and it's here to stay. Get your hands on this comfy white tee with the new Google icon.&amp;nbsp;\n\n&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&amp;nbsp;&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% combed and ring-spun cotton.&lt;/li&gt;&lt;li&gt;Side seamed, relaxed fit.&lt;/li&gt;&lt;li&gt;Bella+Canvas.&lt;/li&gt;&lt;li&gt;Available in white with the Google 'G' icon screenprinted at front.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-23178B.jpg",
-    "largeImage":"/data/images/10-23178A.jpg"
+    "image":"data/images/10-23178B.jpg",
+    "largeImage":"data/images/10-23178A.jpg"
   },
   {
     "name":"Ladies+Android+Pride+T-Shirt",
@@ -41,8 +41,8 @@
     "category":"ladies_tshirts",
     "price":19.10,
     "description":"Stand out proud in this Ladies' Android Pride T-shirt.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% cotton.&lt;/li&gt;&lt;li&gt;Available in black and features two Androids holding hands and waving a rainbow flag printed across the front. Google logo screen printed in white on the sleeve.&amp;nbsp;&lt;/li&gt;&lt;li&gt;&lt;b&gt;Sizing runs smaller than normal. Please reference size chart before ordering.&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-23177B.jpg",
-    "largeImage":"/data/images/10-23177A.jpg"
+    "image":"data/images/10-23177B.jpg",
+    "largeImage":"data/images/10-23177A.jpg"
   },
   {
     "name":"Ladies+Ringspun+Crew+Neck",
@@ -50,8 +50,8 @@
     "category":"ladies_tshirts",
     "price":19.70,
     "description":"Cheery colors make the world a happier place. This bright pink tee is ultra soft and features a comfortable, ladies fit.&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% cotton.&lt;/li&gt;&lt;li&gt;Tagless label for added comfort.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Relaxed fit.&lt;/b&gt;&lt;/li&gt;&lt;li&gt;Available in hot pink with the white Google logo screenprinted at center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-23172B.jpg",
-    "largeImage":"/data/images/10-23172A.jpg"
+    "image":"data/images/10-23172B.jpg",
+    "largeImage":"data/images/10-23172A.jpg"
   },
   {
     "name":"Ladies+Tri-Blend+V-Neck+T-Shirt",
@@ -59,8 +59,8 @@
     "category":"ladies_tshirts",
     "price":35.10,
     "description":"A tagless label, ultra soft triblend fabric and v-neck cut are three ingredients for a favorite tee.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;25% cotton, 50% polyester, 25% rayon.&lt;/li&gt;&lt;li&gt;Made in California.&lt;/li&gt;&lt;li&gt;Available in green with the white Google logo screenprinted at center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-23227B.jpg",
-    "largeImage":"/data/images/10-23227A.jpg"
+    "image":"data/images/10-23227B.jpg",
+    "largeImage":"data/images/10-23227A.jpg"
   },
   {
     "name":"Bella+Ladies+Favorite+Tee",
@@ -68,8 +68,8 @@
     "category":"ladies_tshirts",
     "price":10.50,
     "description":"This ladies tee features a longer body length perfect for layering up.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% combed, ringspun cotton.&lt;/li&gt;&lt;li&gt;Extra soft, lightweight fabric.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Slim fit. Runs small.&amp;nbsp;&lt;/b&gt;&lt;/li&gt;&lt;li&gt;Available in aqua with the white Google logo screenprinted at center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-23228B.jpg",
-    "largeImage":"/data/images/10-23228A.jpg"
+    "image":"data/images/10-23228B.jpg",
+    "largeImage":"data/images/10-23228A.jpg"
   },
   {
     "name":"Ladies+Bamboo+T-Shirt",
@@ -77,8 +77,8 @@
     "category":"ladies_tshirts",
     "price":20.65,
     "description":"A bamboo tee that's softer than your favorite cotton t-shirt. Your skin will thank you during those long nights of programming.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;70% viscose from organic bamboo, 30% organic cotton.&lt;/li&gt;&lt;li&gt;Available in vintage pink with the white Google logo screen printed at center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-23176B.jpg",
-    "largeImage":"/data/images/10-23176A.jpg"
+    "image":"data/images/10-23176B.jpg",
+    "largeImage":"data/images/10-23176A.jpg"
   },
   {
     "name":"Ladies+L+S+Colorblock+Raglan",
@@ -86,8 +86,8 @@
     "category":"ladies_tshirts",
     "price":36.95,
     "description":"Add a dose of mango to your t-shirt lineup. This scoop neck raglan features a bright pop of color and a scoop neck with v-notch.&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;60% cotton, 40% polyester.&lt;/li&gt;&lt;li&gt;Scoop hem.&lt;/li&gt;&lt;li&gt;Self-fabric cuff bands.&lt;/li&gt;&lt;li&gt;Available in heather/mango with the white Google logo screenprinted at center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-23173B.jpg",
-    "largeImage":"/data/images/10-23173A.jpg"
+    "image":"data/images/10-23173B.jpg",
+    "largeImage":"data/images/10-23173A.jpg"
   },
   {
     "name":"Bella+Scoop-Neck+Ladies+T-Shirt",
@@ -95,8 +95,8 @@
     "category":"ladies_tshirts",
     "price":13.10,
     "description":"A classic that's here to stay is this ladies white baby ribbed tee. Features a feminine scoop cut at the neck and 1x1 baby rib texture. Available in white with the full color Google logo screen printed at center chest.",
-    "image":"/data/images/10-23171B.jpg",
-    "largeImage":"/data/images/10-23171A.jpg"
+    "image":"data/images/10-23171B.jpg",
+    "largeImage":"data/images/10-23171A.jpg"
   },
   {
     "name":"Ladies+Not+For+Sale+T-Shirt",
@@ -104,8 +104,8 @@
     "category":"ladies_tshirts",
     "price":24.00,
     "description":"This Not for Sale t-shirt features just the right amount of 'V' around the neck with the Google logo placed perfectly underneath. Not for Sale focuses efforts on growing social enterprises to benefit those enslaved and vulnerable communities around the world.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;Available in black with the Google logo imprinted in white across upper chest.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Sizing runs smaller than normal. Please consider ordering up one or two sizes.&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-23225B.jpg",
-    "largeImage":"/data/images/10-23225A.jpg"
+    "image":"data/images/10-23225B.jpg",
+    "largeImage":"data/images/10-23225A.jpg"
   },
   {
     "name":"Ladies+Android+L+S+Stretch+T-Shirt",
@@ -113,8 +113,8 @@
     "category":"ladies_tshirts",
     "price":20.00,
     "description":"Sparkle and shine in this ladies long sleeve stretch tee.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features;&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;95% premium, ring-spun cotton, 5% spandex.&lt;/li&gt;&lt;li&gt;Available in Black with a glitter Android robot at left chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-23198B.jpg",
-    "largeImage":"/data/images/10-23198A.jpg"
+    "image":"data/images/10-23198B.jpg",
+    "largeImage":"data/images/10-23198A.jpg"
   },
   {
     "name":"Ladies+Mountain+View+T-Shirt",
@@ -122,8 +122,8 @@
     "category":"ladies_tshirts",
     "price":17.50,
     "description":"The Bay Area city named for its beautiful views of the Santa Cruz Mountains is also home to the Googleplex located at 1600 Amphitheater Parkway. Celebrate the place Google calls home in this ladies scoop neck tee.&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% cotton.&lt;/li&gt;&lt;li&gt;Available in white with the Mountain View coordinates screenprinted at front and the full color Google logo screenprinted at back yoke.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-23229B.jpg",
-    "largeImage":"/data/images/10-23229A.jpg"
+    "image":"data/images/10-23229B.jpg",
+    "largeImage":"data/images/10-23229A.jpg"
   },
   {
     "name":"Ladies+Blueprint+for+a+Better+Inbox+T-Shirt",
@@ -131,8 +131,8 @@
     "category":"ladies_tshirts",
     "price":14.30,
     "description":"The \"Blueprint for  better Inbox\" now available for the ladies! This USA made American Apparel t-shirt sports a more fitted design and &amp;nbsp;the new Inbox logo.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Additional Features:&amp;nbsp;&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;50% cotton / 50% polyester for a super soft fit.&lt;/li&gt;&lt;li&gt;Available in royal blue heather with the \"New Inbox: logo screen printed on the center chest.&amp;nbsp;&lt;/li&gt;&lt;li&gt;&lt;b&gt;Sizing runs smaller than normal. Please reference sizing chart prior to ordering.&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-23169B.jpg",
-    "largeImage":"/data/images/10-23169A.jpg"
+    "image":"data/images/10-23169B.jpg",
+    "largeImage":"data/images/10-23169A.jpg"
   },
   {
     "name":"Ladies+Cotton+Poly+w++Thermal+Tee",
@@ -140,8 +140,8 @@
     "category":"ladies_tshirts",
     "price":15.15,
     "description":"This thermal long sleeve t-shirt is lightweight enough for all seasons of the year.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;60% cotton, 40% polyester.&lt;/li&gt;&lt;li&gt;Wide boat neck, thermal sleeves and hight length thermal cuffs.&lt;/li&gt;&lt;li&gt;Longer body for comfortable fit.&lt;/li&gt;&lt;li&gt;Available in blue/black with the white Google logo screenprinted at center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-23174B.jpg",
-    "largeImage":"/data/images/10-23174A.jpg"
+    "image":"data/images/10-23174B.jpg",
+    "largeImage":"data/images/10-23174A.jpg"
   },
   {
     "name":"Ladies+YouTube+Favorite+Tee",
@@ -149,8 +149,8 @@
     "category":"ladies_tshirts",
     "price":11.10,
     "description":"It's called the 'favorite tee' for a reason. Designed with fashion and comfort in mind, this ladies tee is ultra soft and provides a great fit, every time.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% combed, ring-spun cotton.&lt;/li&gt;&lt;li&gt;Designed with a longer length for varying body types.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Available in asphalt with the full color YouTube logo screen printed across center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-23073B.jpg",
-    "largeImage":"/data/images/10-23073A.jpg"
+    "image":"data/images/10-23073B.jpg",
+    "largeImage":"data/images/10-23073A.jpg"
   },
   {
     "name":"MTV+Ladies+Yellow+T-Shirt",
@@ -158,8 +158,8 @@
     "category":"ladies_tshirts",
     "price":16.90,
     "description":"They say home is where the heart is. This vibrant tee features the Bay Area address of Google's head office. &amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% combed cotton.&lt;/li&gt;&lt;li&gt;Made in the USA.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Available in gold with a striking design at front and the white Google logo at back yoke.&amp;nbsp;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-23230B.jpg",
-    "largeImage":"/data/images/10-23230A.jpg"
+    "image":"data/images/10-23230B.jpg",
+    "largeImage":"data/images/10-23230A.jpg"
   },
   {
     "name":"Women+s+Android+Heart+T-Shirt",
@@ -167,7 +167,7 @@
     "category":"ladies_tshirts",
     "price":10.60,
     "description":"The softest, smoothest, best-looking, organic cotton tee shirt available anywhere.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% certified organic, combed, ringspun cotton.&lt;/li&gt;&lt;li&gt;Contoured to flatter women's curves.&lt;/li&gt;&lt;li&gt;Double-needle stitching on the sleeves and bottom hem.&lt;/li&gt;&lt;li&gt;TearAway™ label for added comfort.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Available in Berry with a screened Android robot at front chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-23069B.jpg",
-    "largeImage":"/data/images/10-23069A.jpg"
+    "image":"data/images/10-23069B.jpg",
+    "largeImage":"data/images/10-23069A.jpg"
   }
 ]

--- a/data/mens_outerwear.json
+++ b/data/mens_outerwear.json
@@ -5,8 +5,8 @@
     "category":"mens_outerwear",
     "price":50.20,
     "description":"A versatile full-zip that you can wear all day long and even to the gym. This technical shell features moisture-wicking fabric, added stretch and a hidden pocket for your smartphone or media player.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% polyester.&lt;/li&gt;&lt;li&gt;Smooth, technical front with textured mesh back.&lt;/li&gt;&lt;li&gt;Drawstring bottom for adjustable fit.&lt;/li&gt;&lt;li&gt;Raglan sleeves.&lt;/li&gt;&lt;li&gt;Available in forest green with the white Google logo embroidered at left chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-15068B.jpg",
-    "largeImage":"/data/images/10-15068A.jpg"
+    "image":"data/images/10-15068B.jpg",
+    "largeImage":"data/images/10-15068A.jpg"
   },
   {
     "name":"Anvil+L+S+Crew+Neck+-+Grey",
@@ -14,8 +14,8 @@
     "category":"mens_outerwear",
     "price":22.15,
     "description":"You'll be swooning over this crew neck as soon as you feel how soft it is.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;40% preshrunk ring-spun cotton, 60% polyester terry fleece.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Available in dark heather charcoal with the white Google logo screen printed across center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-14154B.jpg",
-    "largeImage":"/data/images/10-14154A.jpg"
+    "image":"data/images/10-14154B.jpg",
+    "largeImage":"data/images/10-14154A.jpg"
   },
   {
     "name":"Green+Flex+Fleece+Zip+Hoodie",
@@ -23,8 +23,8 @@
     "category":"mens_outerwear",
     "price":45.65,
     "description":"Ultra soft. Ultra cozy. Our popular flex fleece hoodie now available in speckled green.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;50% cotton / 50% polyester.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Made in the USA.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Full-zip.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Available in green with specks of blue and the white Google logo embroidered at left bicep.&amp;nbsp;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-14157B.jpg",
-    "largeImage":"/data/images/10-14157A.jpg"
+    "image":"data/images/10-14157B.jpg",
+    "largeImage":"data/images/10-14157A.jpg"
   },
   {
     "name":"Android+Nylon+Packable+Jacket",
@@ -32,8 +32,8 @@
     "category":"mens_outerwear",
     "price":33.60,
     "description":"Pack. Pack. Pack it up! This nylon jacket with reflective trim can literally be packed into itself in seconds. Features a waterproof nylon fabric, Android eyes &amp;amp; antennaes on the hood and a  carrying strap when jacket is fully packed. Android robot is printed on back above zipper in a reflective, metallic finish.",
-    "image":"/data/images/10-15041B.jpg",
-    "largeImage":"/data/images/10-15041A.jpg"
+    "image":"data/images/10-15041B.jpg",
+    "largeImage":"data/images/10-15041A.jpg"
   },
   {
     "name":"YouTube+Ultimate+Hooded+Sweatshirt",
@@ -41,8 +41,8 @@
     "category":"mens_outerwear",
     "price":32.35,
     "description":"Stay warm in this cozy hoodie made of 50% cotton and 50% polyester. This comfortable design features set in sleeves, dyed to match draw cord and a front pouch pocket. Available in Charcoal with the full color YouTube logo screen printed across the chest. Unisex sizing.",
-    "image":"/data/images/10-14133B.jpg",
-    "largeImage":"/data/images/10-14133A.jpg"
+    "image":"data/images/10-14133B.jpg",
+    "largeImage":"data/images/10-14133A.jpg"
   },
   {
     "name":"Grey+Heather+Fleece+Zip+Hoodie",
@@ -50,8 +50,8 @@
     "category":"mens_outerwear",
     "price":38.85,
     "description":"Cozy up with this full-zip hoodie.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;60% combed, ring-spun cotton, 40% polyester.&lt;/li&gt;&lt;li&gt;Unisex sizing.&lt;/li&gt;&lt;li&gt;Retail fit.&lt;/li&gt;&lt;li&gt;Contrast zipper.&lt;/li&gt;&lt;li&gt;Kangaroo pockets with ribbed cuffs and waistband.&lt;/li&gt;&lt;li&gt;Available in dark heather with the white Google logo embroidered at left chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;&lt;div&gt;&lt;br&gt;&lt;/div&gt;",
-    "image":"/data/images/10-14160B.jpg",
-    "largeImage":"/data/images/10-14160A.jpg"
+    "image":"data/images/10-14160B.jpg",
+    "largeImage":"data/images/10-14160A.jpg"
   },
   {
     "name":"Vastrm+Hoodie",
@@ -59,8 +59,8 @@
     "category":"mens_outerwear",
     "price":200.00,
     "description":"The ultimate in fit and fabric, this Vastrm hoodie doesn't disappoint. Made from soft pique fabric, the lightweight full-zip features a halfmoon accent and matching hoodie strings.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Additional Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% cotton.&lt;/li&gt;&lt;li&gt;Hidden phone pocket neatly cradles your digital device.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Available in charcoal grey with red strings and hood. White Google logo is embroidered at left bicep.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-14153B.jpg",
-    "largeImage":"/data/images/10-14153A.jpg"
+    "image":"data/images/10-14153B.jpg",
+    "largeImage":"data/images/10-14153A.jpg"
   },
   {
     "name":"Recycled+Plastic+Bottle+Hoodie+-+Green",
@@ -68,8 +68,8 @@
     "category":"mens_outerwear",
     "price":60.95,
     "description":"Ever wonder where all of the disposable water bottles of the world end up? We know some of them are reused for a second purpose. Each of these hoodies contain approximately 9 recycled water bottles that are woven into the fabric.&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&amp;nbsp;&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;50% recycled cotton, 50% recycled polyester.&lt;/li&gt;&lt;li&gt;Full zipper and orange drawstring pulls.&lt;/li&gt;&lt;li&gt;USA made.&amp;nbsp;&lt;/li&gt;&lt;li&gt;&amp;nbsp;Available in forest green with the white Google logo embroidered at left bicep.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-14158B.jpg",
-    "largeImage":"/data/images/10-14158A.jpg"
+    "image":"data/images/10-14158B.jpg",
+    "largeImage":"data/images/10-14158A.jpg"
   },
   {
     "name":"Rowan+Pullover+Hood",
@@ -77,8 +77,8 @@
     "category":"mens_outerwear",
     "price":60.85,
     "description":"In search of the perfect layering piece? This lightweight, triblend pullover is ultra soft and ideal for all seasons.&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;50% polyester, 38% cotton, 12% rayon triblend.&lt;/li&gt;&lt;li&gt;Available in black with the white Google logo screenprinted at left bicep.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-14152B.jpg",
-    "largeImage":"/data/images/10-14152A.jpg"
+    "image":"data/images/10-14152B.jpg",
+    "largeImage":"data/images/10-14152A.jpg"
   },
   {
     "name":"Men+s+Voyage+Fleece+Jacket",
@@ -86,8 +86,8 @@
     "category":"mens_outerwear",
     "price":48.00,
     "description":"&lt;div&gt;Perhaps the equivalent to that comfort blanket you had years ago is a cozy fleece. This full-zip is the perfect layering piece for those 'in-between' months when mother nature just can't make up her mind.&amp;nbsp;&lt;/div&gt;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% polyester anti-pill yarn fleece.&lt;/li&gt;&lt;li&gt;100% polyester taffeta lining in sleeves.&lt;/li&gt;&lt;li&gt;Tricot-lined lower pockets with reverse coil zippers.&lt;/li&gt;&lt;li&gt;Available in black with the white Google logo embroidered at left chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-14155B.jpg",
-    "largeImage":"/data/images/10-14155A.jpg"
+    "image":"data/images/10-14155B.jpg",
+    "largeImage":"data/images/10-14155A.jpg"
   },
   {
     "name":"Eco-Jersey+Chrome+Zip+Up+Hoodie",
@@ -95,8 +95,8 @@
     "category":"mens_outerwear",
     "price":37.75,
     "description":"An exceptionally soft, eco-friendly full-zip for picture-perfect layering.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;50% polyester, 38% cotton (6.25% recycled), 12% rayon (6.25% organic).&lt;/li&gt;&lt;li&gt;Low-impact yarn dyed and washed.&lt;/li&gt;&lt;li&gt;Brushed nickel zipper with natural taping.&lt;/li&gt;&lt;li&gt;Split front pouch pocket.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Available in deep pacific blue with the white Google Chrome logo screenprinted at left chest.&amp;nbsp;&lt;/li&gt;&lt;/ul&gt;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;/div&gt;",
-    "image":"/data/images/10-14159B.jpg",
-    "largeImage":"/data/images/10-14159A.jpg"
+    "image":"data/images/10-14159B.jpg",
+    "largeImage":"data/images/10-14159A.jpg"
   },
   {
     "name":"Android+Colorblock+Hooded+Pullover",
@@ -104,8 +104,8 @@
     "category":"mens_outerwear",
     "price":50.20,
     "description":"This cozy Android hoodie features a sublimated camo design printed inside hood and along inner sleeves and side panels.  Moisture-wicking polyester fabric keeps you cool and dry.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% polyester.&lt;/li&gt;&lt;li&gt;Ultra soft, fleece interior.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Available in smoke/lime green with the white Android robot embroidered at left chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-14146B.jpg",
-    "largeImage":"/data/images/10-14146A.jpg"
+    "image":"data/images/10-14146B.jpg",
+    "largeImage":"data/images/10-14146A.jpg"
   },
   {
     "name":"Tri-blend+Full-Zip+Hoodie",
@@ -113,8 +113,8 @@
     "category":"mens_outerwear",
     "price":52.20,
     "description":"Comfy cool. This canvas tri-blend full-zip hoodie made of a poly/cotton/rayon blend is sure to please the eyes as well as the senses. Made in the USA. Available in Black with the white Google logo embroidered at left chest.",
-    "image":"/data/images/10-14216B.jpg",
-    "largeImage":"/data/images/10-14216A.jpg"
+    "image":"data/images/10-14216B.jpg",
+    "largeImage":"data/images/10-14216A.jpg"
   },
   {
     "name":"Fleece+Full-Zip+Hoodie",
@@ -122,8 +122,8 @@
     "category":"mens_outerwear",
     "price":45.65,
     "description":"If you find that the 'spark' is missing from your outfit, you may need to add one of these full-zip hoodies to the mix. Resurfacing from 1989, this colorful full-zip features a sporty fit with ultra soft fleece lining.&lt;div&gt;&lt;br&gt;&lt;div&gt;Additional Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;50% polyester and 50% cotton fleece.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Available in blue with the Google logo embroidered in white at left bicep.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;&lt;/div&gt;",
-    "image":"/data/images/10-14215B.jpg",
-    "largeImage":"/data/images/10-14215A.jpg"
+    "image":"data/images/10-14215B.jpg",
+    "largeImage":"data/images/10-14215A.jpg"
   },
   {
     "name":"Jacquard-Knit+Full-Zip+Fleece",
@@ -131,8 +131,8 @@
     "category":"mens_outerwear",
     "price":74.90,
     "description":"We love color contrast, especially in Google Blue! This textured jacket features a jacquard texture with contrast stitching and zippers.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Additional Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% polyester.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Audio port access available on inside left pocket.&lt;/li&gt;&lt;li&gt;Available in Carbon/Olympic Blue with the Google logo embroidered in white on left chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-14217B.jpg",
-    "largeImage":"/data/images/10-14217A.jpg"
+    "image":"data/images/10-14217B.jpg",
+    "largeImage":"data/images/10-14217A.jpg"
   },
   {
     "name":"YouTube+Unisex+Flex+Fleece+Zip+Hoodie",
@@ -140,7 +140,7 @@
     "category":"mens_outerwear",
     "price":45.25,
     "description":"Our popular flex fleece hoodie, now for YouTube fans everywhere.&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;50% polyester, 50% cotton fleece.&lt;/li&gt;&lt;li&gt;Sporty, unisex fit.&lt;/li&gt;&lt;li&gt;Metal zipper.&lt;/li&gt;&lt;li&gt;Hood.&lt;/li&gt;&lt;li&gt;Available in dark heather grey with the YouTube logo embroidered at left bicep.&lt;/li&gt;&lt;/ul&gt;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;/div&gt;",
-    "image":"/data/images/10-15103B.jpg",
-    "largeImage":"/data/images/10-15103A.jpg"
+    "image":"data/images/10-15103B.jpg",
+    "largeImage":"data/images/10-15103A.jpg"
   }
 ]

--- a/data/mens_tshirts.json
+++ b/data/mens_tshirts.json
@@ -5,8 +5,8 @@
     "category":"mens_tshirts",
     "price":14.75,
     "description":"Stay casual and cool in this 100% organic pre-shrunk cotton T-shirt. Available in charcoal grey with full-color YouTube logo screened on front.",
-    "image":"/data/images/10-13058B.jpg",
-    "largeImage":"/data/images/10-13058A.jpg"
+    "image":"data/images/10-13058B.jpg",
+    "largeImage":"data/images/10-13058A.jpg"
   },
   {
     "name":"Inbox+-+Subtle+Actions+T-Shirt",
@@ -14,8 +14,8 @@
     "category":"mens_tshirts",
     "price":17.05,
     "description":"Sometimes even the subtlest of actions can make a big difference. This tee highlights all of the icons &amp;amp; features available in your Gmail inbox!&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;60% cotton, 40% polyester blend.&lt;/li&gt;&lt;li&gt;Available in charcoal heather with the inbox icons screenprinted at front chest and inbox tag sewn onto left sleeve.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13256B.jpg",
-    "largeImage":"/data/images/10-13256A.jpg"
+    "image":"data/images/10-13256B.jpg",
+    "largeImage":"data/images/10-13256A.jpg"
   },
   {
     "name":"Adult+Android+Superhero+T-Shirt",
@@ -23,8 +23,8 @@
     "category":"mens_tshirts",
     "price":14.95,
     "description":"Mr. Kent has nothing on Super Droid, especially since this robot has only one weakness-a sweet tooth (considering all of its confectionery-themed versions)! This adorable Bella+Canvas tee features a unisex fit that is sure to please both male and female Android fans.&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Additional Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% combed, ringspun cotton.&lt;/li&gt;&lt;li&gt;Unisex fit.&lt;/li&gt;&lt;li&gt;Tag-free label for added comfort.&lt;/li&gt;&lt;li&gt;Available in royal blue with the Super Droid robot screen printed at center chest.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Sizes run smaller than normal. Reference men's sizing chart for additional details.&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13239B.jpg",
-    "largeImage":"/data/images/10-13239A.jpg"
+    "image":"data/images/10-13239B.jpg",
+    "largeImage":"data/images/10-13239A.jpg"
   },
   {
     "name":"Men+s+Vintage+Heather+T-Shirt",
@@ -32,8 +32,8 @@
     "category":"mens_tshirts",
     "price":15.8,
     "description":"&lt;div&gt;A casual-cool, vintage-inspired tee perfect for all. Just remember that the best part about any classic is that it only improves with age. The more you wash it, the softer it feels.&amp;nbsp;&lt;/div&gt;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;65% polyester, 35% cotton.&lt;/li&gt;&lt;li&gt;Available in heather navy, blue, purple or green with the white Google logo screened across center chest of each.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13264B.jpg",
-    "largeImage":"/data/images/10-13264A.jpg"
+    "image":"data/images/10-13264B.jpg",
+    "largeImage":"data/images/10-13264A.jpg"
   },
   {
     "name":"Basic+Black+T-Shirt",
@@ -41,8 +41,8 @@
     "category":"mens_tshirts",
     "price":16.9,
     "description":"Word on the street is that 'black is the new black.' Embellish your basic fashion statement with the Google logo on an authentic American Apparel t-shirt.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% organic combed cotton for ultimate softness.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Flattering fit.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Available in Black with the Google logo screen printed in White across center chest.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Sizes run smaller than normal.&lt;/b&gt;&amp;nbsp;&lt;b&gt;Please reference men's size chart for fit.&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13265B.jpg",
-    "largeImage":"/data/images/10-13265A.jpg"
+    "image":"data/images/10-13265B.jpg",
+    "largeImage":"data/images/10-13265A.jpg"
   },
   {
     "name":"Local+Guides+T-Shirt",
@@ -50,8 +50,8 @@
     "category":"mens_tshirts",
     "price":15.7,
     "description":"Do you live to explore? Are you the first to tell your friends about the best venues, restaurants and hot spots in town? If you're already a local guide, sport your t-shirt with pride. This ultra soft style is comfortable enough to wear all day long - perfect for all of those adventures you'll tell us about later. To learn more about Local Guides, visit us here:&amp;nbsp;https://www.google.com/local/guides/.&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;52% combed, ring-spun cotton / 48% polyester.&lt;/li&gt;&lt;li&gt;Retail fit.&lt;/li&gt;&lt;li&gt;Available in charcoal with the Local Guides logo screenprinted at front chest and Google logo screenprinted in white at left bicep.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13280B.jpg",
-    "largeImage":"/data/images/10-13280A.jpg"
+    "image":"data/images/10-13280B.jpg",
+    "largeImage":"data/images/10-13280A.jpg"
   },
   {
     "name":"Go+Gopher+T-Shirt+in+Teal",
@@ -59,8 +59,8 @@
     "category":"mens_tshirts",
     "price":10.95,
     "description":"Go anywhere in style when wearing this t-shirt featuring The Go Gopher. &amp;nbsp;Tee is made of 100% combed, ring-spun cotton jersey fabric. Available in teal with the Go Gopher screen printed on center.",
-    "image":"/data/images/10-13213B.jpg",
-    "largeImage":"/data/images/10-13213A.jpg"
+    "image":"data/images/10-13213B.jpg",
+    "largeImage":"data/images/10-13213A.jpg"
   },
   {
     "name":"Android+Ringspun+T-Shirt+-+Green",
@@ -68,8 +68,8 @@
     "category":"mens_tshirts",
     "price":8.75,
     "description":"Display your undying love for Androids everywhere in this 100% certified organic ringspun cotton tee.&amp;nbsp;\n&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Additional Features:&amp;nbsp;&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% combed, ring-spun cotton.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Preshrunk for fashion fit.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Tearaway label.&amp;nbsp;\n&lt;/li&gt;&lt;li&gt;Available in heather green with the full color Android robot screen printed across center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13285B.jpg",
-    "largeImage":"/data/images/10-13285A.jpg"
+    "image":"data/images/10-13285B.jpg",
+    "largeImage":"data/images/10-13285A.jpg"
   },
   {
     "name":"Organic+Cotton+Android+walking+with+dog+T-shirt",
@@ -77,8 +77,8 @@
     "category":"mens_tshirts",
     "price":17.25,
     "description":"What’s better than an organic cotton t-shirt with the Android logo?  How about a t-shirt with the Android walking a dog.&amp;nbsp; &lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% smooth organic cotton.&lt;/li&gt;&lt;li&gt;Available in black with the Android design screenprinted at front chest.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Sizing runs smaller than normal. Please reference size chart before ordering.&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13018B.jpg",
-    "largeImage":"/data/images/10-13018A.jpg"
+    "image":"data/images/10-13018B.jpg",
+    "largeImage":"data/images/10-13018A.jpg"
   },
   {
     "name":"Organic+Cotton+T-Shirt+-+Red",
@@ -86,8 +86,8 @@
     "category":"mens_tshirts",
     "price":14.4,
     "description":"Looking to add a little color to your wardrobe? This striking red tee shirt is made of 100% preshrunk organic cotton, so it's healthy for the environment as well as for your look.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;Shoulder-to-shoulder tape.&lt;/li&gt;&lt;li&gt;Seamless collar.&lt;/li&gt;&lt;li&gt;Available in red with white Google logo screenprinted at center chest.&lt;/li&gt;&lt;li&gt;&lt;b&gt;**This shirt's cut is more of a generous t-shirt cut. Compared to the American Apparel shirts, sizing would run larger.**&amp;nbsp;&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13270B.jpg",
-    "largeImage":"/data/images/10-13270A.jpg"
+    "image":"data/images/10-13270B.jpg",
+    "largeImage":"data/images/10-13270A.jpg"
   },
   {
     "name":"Unisex+Gmail+T-Shirt",
@@ -95,8 +95,8 @@
     "category":"mens_tshirts",
     "price":15,
     "description":"Show your inbox some love. The new Gmail tee has arrived, complete with a subtle Mvelope design that showcases all of the Gmail icons you use on the daily.&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;52% cotton / 48% polyester.&lt;/li&gt;&lt;li&gt;Unisex fit.&lt;/li&gt;&lt;li&gt;Bella+Canvas.&lt;/li&gt;&lt;li&gt;Available in dark grey heather with the new Gmail print screenprinted across center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13282B.jpg",
-    "largeImage":"/data/images/10-13282A.jpg"
+    "image":"data/images/10-13282B.jpg",
+    "largeImage":"data/images/10-13282A.jpg"
   },
   {
     "name":"Android+Soccer+T-Shirt",
@@ -104,8 +104,8 @@
     "category":"mens_tshirts",
     "price":15.2,
     "description":"When it comes to futbol formation, the world's most adorable robots are en pointe. Show your love for the game with this limited edition Android tee.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% cotton.&lt;/li&gt;&lt;li&gt;Made in the USA.&lt;/li&gt;&lt;li&gt;Available in navy with the Android robot design screenprinted at front.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13289B.jpg",
-    "largeImage":"/data/images/10-13289A.jpg"
+    "image":"data/images/10-13289B.jpg",
+    "largeImage":"data/images/10-13289A.jpg"
   },
   {
     "name":"Basic+Google+T-Shirt",
@@ -113,8 +113,8 @@
     "category":"mens_tshirts",
     "price":13.3,
     "description":"Embellish your basic fashion statement with Google's brightly colored logo. Featuring a flattering and stylish fit for virtually any body type, this tee also boasts an ultra-soft feel.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% cotton.&lt;/li&gt;&lt;li&gt;Stretchable, reinforced shoulder construction maintains shape through repeated washings.&lt;/li&gt;&lt;li&gt;Double-stitched bottom hem ensures durability.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Available in white with the full color Google logo screenprinted across chest.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Sizes run smaller than normal.&lt;/b&gt;&amp;nbsp;&lt;b&gt;Please reference men's size chart for fit.&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13262B.jpg",
-    "largeImage":"/data/images/10-13262A.jpg"
+    "image":"data/images/10-13262B.jpg",
+    "largeImage":"data/images/10-13262A.jpg"
   },
   {
     "name":"Tri-Blend+V-Neck+Tee",
@@ -122,8 +122,8 @@
     "category":"mens_tshirts",
     "price":14.95,
     "description":"An ultra soft triblend fabric and fashionable v-neck cut make this tee perfect for everyday wear. Available in royal blue with the white Google logo screenprinted at center chest.",
-    "image":"/data/images/10-13273B.jpg",
-    "largeImage":"/data/images/10-13273A.jpg"
+    "image":"data/images/10-13273B.jpg",
+    "largeImage":"data/images/10-13273A.jpg"
   },
   {
     "name":"Heather+Pocket+Tee+-+Light+Blue",
@@ -131,8 +131,8 @@
     "category":"mens_tshirts",
     "price":23.3,
     "description":"Pocket protector or not, you're sure to look pretty cool in this stylish tee.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;60% cotton, 40% polyester.&lt;/li&gt;&lt;li&gt;Tagless label for added comfort.&lt;/li&gt;&lt;li&gt;Available in light blue with a grey pocket and the white Google logo screenprinted at center pocket.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13272B.jpg",
-    "largeImage":"/data/images/10-13272A.jpg"
+    "image":"data/images/10-13272B.jpg",
+    "largeImage":"data/images/10-13272A.jpg"
   },
   {
     "name":"Google+Now+Skyline+T-Shirt",
@@ -140,8 +140,8 @@
     "category":"mens_tshirts",
     "price":20.2,
     "description":"A bright and sunny 360° illustration of San Francisco wrapped around this American Apparel t-shirt. This tee, popular at the Googleplex in Mountain View, CA is now available just for you!&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% cotton.&lt;/li&gt;&lt;li&gt;Available in Aqua with the Google Now logo screen printed in Gray across chest.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Sizes run smaller than normal.&lt;/b&gt;&amp;nbsp;&lt;b&gt;Please reference men's size chart for fit.&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13276B.jpg",
-    "largeImage":"/data/images/10-13276A.jpg"
+    "image":"data/images/10-13276B.jpg",
+    "largeImage":"data/images/10-13276A.jpg"
   },
   {
     "name":"Tri-Blend+G+Logo+Men+s+Polo",
@@ -149,8 +149,8 @@
     "category":"mens_tshirts",
     "price":32.7,
     "description":"Stock up on this comfy-cool polo featuring the new Google 'G.'&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;50% polyester / 25% cotton / 25% rayon&lt;/li&gt;&lt;li&gt;Tri-blend fabric retains shape and elasticity.&lt;/li&gt;&lt;li&gt;Retail fit.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Single front pocket.&lt;/li&gt;&lt;li&gt;Three-button placket.&lt;/li&gt;&lt;li&gt;Structured collar holds shape through repeated washing.&lt;/li&gt;&lt;li&gt;Available in black with the Google 'G' icon embroidered at left chest.&amp;nbsp;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-11019B.jpg",
-    "largeImage":"/data/images/10-11019A.jpg"
+    "image":"data/images/10-11019B.jpg",
+    "largeImage":"data/images/10-11019A.jpg"
   },
   {
     "name":"Tri-Blend+Leisure+Shirt",
@@ -158,8 +158,8 @@
     "category":"mens_tshirts",
     "price":32.95,
     "description":"Dress it up, or dress it down. We promise you'll fall in love with the versatility of this triblend polo.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&amp;nbsp;&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;50/25/25 polyester/cotton/rayon blend.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Three-button placket with structured self-fabric collar and left chest pocket.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Available in black with the Google logo embroidered at right sleeve.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Sizes run smaller than normal. Please reference size chart before ordering.&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-11017B.jpg",
-    "largeImage":"/data/images/10-11017A.jpg"
+    "image":"data/images/10-11017B.jpg",
+    "largeImage":"data/images/10-11017A.jpg"
   },
   {
     "name":"Wise+Android+T-Shirt",
@@ -167,8 +167,8 @@
     "category":"mens_tshirts",
     "price":14.95,
     "description":"Take a word from the wise: put on this tee and you'll fall in love! Made of 100% preshrunk certified organic cotton for ultimate softness. Available in black with the Wise Android screen printed on the front chest.",
-    "image":"/data/images/10-13153B.jpg",
-    "largeImage":"/data/images/10-13153A.jpg"
+    "image":"data/images/10-13153B.jpg",
+    "largeImage":"data/images/10-13153A.jpg"
   },
   {
     "name":"Android+Pride+T-Shirt",
@@ -176,8 +176,8 @@
     "category":"mens_tshirts",
     "price":19.1,
     "description":"&lt;p&gt;Stand out and stand proud in this Android Pride T-shirt.&amp;nbsp;&lt;/p&gt;&lt;p&gt;Features:&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;ul&gt;&lt;li&gt;100% cotton American Apparel t-shirt.&lt;/li&gt;&lt;li&gt;Available in black, and features two Androids holding hands and waving a rainbow flag screenprinted at center chest. Google logo is screenprinted in white at sleeve.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Sizing runs smaller than normal. Please reference size chart before ordering.&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;",
-    "image":"/data/images/10-13279B.jpg",
-    "largeImage":"/data/images/10-13279A.jpg"
+    "image":"data/images/10-13279B.jpg",
+    "largeImage":"data/images/10-13279A.jpg"
   },
   {
     "name":"Chrome+Unisex+T-Shirt",
@@ -185,8 +185,8 @@
     "category":"mens_tshirts",
     "price":11.35,
     "description":"Show your love for Google Chrome in this 100% combed ring-spun cotton T-Shirt.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;Soft, jersey fabric.&lt;/li&gt;&lt;li&gt;Unisex fit.&lt;/li&gt;&lt;li&gt;Available in dark heather grey with the new Google Chrome logo screenprinted at front.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13286B.jpg",
-    "largeImage":"/data/images/10-13286A.jpg"
+    "image":"data/images/10-13286B.jpg",
+    "largeImage":"data/images/10-13286A.jpg"
   },
   {
     "name":"NY+City+Lights+T-Shirt",
@@ -194,8 +194,8 @@
     "category":"mens_tshirts",
     "price":18.35,
     "description":"Are you feeling lucky? This anniversary t-shirt celebrates the Big Apple.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% cotton American Apparel shirt.&lt;/li&gt;&lt;li&gt;Available in Black with the Google logo and 'I'm Feeling Lucky' New York printed on back yoke in White.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Sizes run smaller than normal. Please reference men's size chart for fit before ordering.&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13271B.jpg",
-    "largeImage":"/data/images/10-13271A.jpg"
+    "image":"data/images/10-13271B.jpg",
+    "largeImage":"data/images/10-13271A.jpg"
   },
   {
     "name":"Omi+Tech+Tee",
@@ -203,8 +203,8 @@
     "category":"mens_tshirts",
     "price":17,
     "description":"This performance tee deserves to be one of your wardrobe staples. Micro-polyester mesh fabric is snag-resistant, moisture-wicking and provides UV protection for sunny days. Available in royal blue with the white Google logo transferred onto center chest.",
-    "image":"/data/images/10-13267B.jpg",
-    "largeImage":"/data/images/10-13267A.jpg"
+    "image":"data/images/10-13267B.jpg",
+    "largeImage":"data/images/10-13267A.jpg"
   },
   {
     "name":"YouTube+S+S+Triblend+T-Shirt",
@@ -212,8 +212,8 @@
     "category":"mens_tshirts",
     "price":14.9,
     "description":"A perfect blend of three fabrics. This fashionably soft tee is perfect for layering or wearing solo.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;50% polyester, 25% combed, ring-spun cotton.&lt;/li&gt;&lt;li&gt;Retail fit.&lt;/li&gt;&lt;li&gt;Unisex sizing.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Available in black with the full color YouTube logo screenprinted at center chest.&amp;nbsp;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13278B.jpg",
-    "largeImage":"/data/images/10-13278A.jpg"
+    "image":"data/images/10-13278B.jpg",
+    "largeImage":"data/images/10-13278A.jpg"
   },
   {
     "name":"Nest+T-Shirt",
@@ -221,8 +221,8 @@
     "category":"mens_tshirts",
     "price":17.4,
     "description":"We know energy savings make you smile. Why not put on an even bigger grin with this teal Nest t-shirt?&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% combed cotton.&lt;/li&gt;&lt;li&gt;Made in the USA.&lt;/li&gt;&lt;li&gt;Available in teal with the white Nest icon screen printed across chest.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Sizing runs smaller than normal. Please reference size chart before ordering.&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13241B.jpg",
-    "largeImage":"/data/images/10-13241A.jpg"
+    "image":"data/images/10-13241B.jpg",
+    "largeImage":"data/images/10-13241A.jpg"
   },
   {
     "name":"98+Short+Sleeve+Tee",
@@ -230,8 +230,8 @@
     "category":"mens_tshirts",
     "price":14.3,
     "description":"Classic front. Retro back. This comfy grey tee celebrates Google's heritage, featuring the vintage '98' logo at back.&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% cotton.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Available in grey with the white Google logo screenprinted at left chest and the vintage '98' screenprinted at back in red, white and blue.&amp;nbsp;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;&lt;div&gt;&lt;br&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13291B.jpg",
-    "largeImage":"/data/images/10-13291A.jpg"
+    "image":"data/images/10-13291B.jpg",
+    "largeImage":"data/images/10-13291A.jpg"
   },
   {
     "name":"Cardboard+T-Shirt",
@@ -239,8 +239,8 @@
     "category":"mens_tshirts",
     "price":14.2,
     "description":"Crazy for Cardboard? Show your love with this super soft t-shirt. If you're new to the virtual reality scene, check out Google Cardboard here:&amp;nbsp;https://www.google.com/get/cardboard/&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;60% cotton, 40% polyester.&lt;/li&gt;&lt;li&gt;Available in charcoal with a Cardboard viewer textured metallic heart at front chest and the Cardboard short url screenprinted at back yoke.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13260B.jpg",
-    "largeImage":"/data/images/10-13260A.jpg"
+    "image":"data/images/10-13260B.jpg",
+    "largeImage":"data/images/10-13260A.jpg"
   },
   {
     "name":"Short+Sleeve+Crew+Neck+Raglan",
@@ -248,8 +248,8 @@
     "category":"mens_tshirts",
     "price":13.1,
     "description":"This vintage style t-shirt features a soft jersey fabric comfortable enough to sleep in.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;60% cotton, 40% polyester.&lt;/li&gt;&lt;li&gt;Self fabric contrast neckband and sleeves.&lt;/li&gt;&lt;li&gt;Available in light blue/indigo with the white Google logo screenprinted across center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13266B.jpg",
-    "largeImage":"/data/images/10-13266A.jpg"
+    "image":"data/images/10-13266B.jpg",
+    "largeImage":"data/images/10-13266A.jpg"
   },
   {
     "name":"MTV+Unisex+Blue+T-Shirt",
@@ -257,8 +257,8 @@
     "category":"mens_tshirts",
     "price":15.75,
     "description":"They say home is where the heart is. This vibrant tee features the Bay Area address of Google's head office.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% combed cotton.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Made in the USA.&lt;/li&gt;&lt;li&gt;Available in royal blue with a striking design at front and the white Google logo at back yoke.&amp;nbsp;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13292B.jpg",
-    "largeImage":"/data/images/10-13292A.jpg"
+    "image":"data/images/10-13292B.jpg",
+    "largeImage":"data/images/10-13292A.jpg"
   },
   {
     "name":"Organic+Me-To-We+Tee",
@@ -266,8 +266,8 @@
     "category":"mens_tshirts",
     "price":23.6,
     "description":"Buy a tee that gives back. Half of the profits from each organic crewneck tee are distributed to the international charity and educational partner, Free the Children.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% organic cotton.&lt;/li&gt;&lt;li&gt;For more information on Free the Children &amp;amp; Me to We, visit http://www.freethechildren.com/about-us/our-story/.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Available in blue with the white Google logo screenprinted at center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13268B.jpg",
-    "largeImage":"/data/images/10-13268A.jpg"
+    "image":"data/images/10-13268B.jpg",
+    "largeImage":"data/images/10-13268A.jpg"
   },
   {
     "name":"Tri-Blend+Raglan+Long+Sleeve",
@@ -275,8 +275,8 @@
     "category":"mens_tshirts",
     "price":51.2,
     "description":"Whether you're stealing second, cheering in the stands, or you just love the look of a classic 'baseball' tee, consider this raglan version for your apparel roster.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;50% polyester, 38% cotton, 12% rayon super soft triblend.&lt;/li&gt;&lt;li&gt;Fashionable fit.&lt;/li&gt;&lt;li&gt;Machine washable.&lt;/li&gt;&lt;li&gt;Available in grey/black with the white Google logo screenprinted at center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13274B.jpg",
-    "largeImage":"/data/images/10-13274A.jpg"
+    "image":"data/images/10-13274B.jpg",
+    "largeImage":"data/images/10-13274A.jpg"
   },
   {
     "name":"Blueprint+for+a+Better+Inbox+T-Shirt",
@@ -284,8 +284,8 @@
     "category":"mens_tshirts",
     "price":14.3,
     "description":"This new \"Blueprint for &amp;nbsp;better Inbox\" t-shirt will be your new favorite t-shirt. &amp;nbsp;It's a USA made American Apparel t-shirt sporting the new logo.&lt;div&gt;&lt;br&gt;&lt;div&gt;Additional Features:&amp;nbsp;&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;50% cotton / 50% polyester for a super soft feel&amp;nbsp;&lt;/li&gt;&lt;li&gt;Unisex fit.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Available in royal blue heather with the \"New Inbox: logo screen printed on the center chest.&lt;/li&gt;&lt;li&gt;&lt;b style=\"\"&gt;Sizing runs smaller than normal. Please reference men's sizing chart prior to ordering.&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13240B.jpg",
-    "largeImage":"/data/images/10-13240A.jpg"
+    "image":"data/images/10-13240B.jpg",
+    "largeImage":"data/images/10-13240A.jpg"
   },
   {
     "name":"YouTube+Player+T-Shirt+-+Unisex",
@@ -293,8 +293,8 @@
     "category":"mens_tshirts",
     "price":17.8,
     "description":"&lt;p&gt;The YouTube Player T-Shirt has arrived. This t-shirt, much coveted by YouTube employees, is now available to the public. Channel your inner player and profess your love for YouTube with this clever design.&amp;nbsp;&lt;/p&gt;&lt;p&gt;Features:&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;ul&gt;&lt;li&gt;100% combed cotton.&lt;/li&gt;&lt;li&gt;Reinforced shoulder construction to maintain shape.&amp;nbsp;&lt;/li&gt;&lt;li&gt;Available in red with the Player logo screenprinted at front chest and YouTube logo screenprinted at back yoke.&lt;/li&gt;&lt;li&gt;&lt;b&gt;Sizes run smaller than normal. Please reference size chart before ordering.&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;&lt;/p&gt;\n&lt;p&gt;&lt;br&gt;&lt;/p&gt;",
-    "image":"/data/images/10-13097B.jpg",
-    "largeImage":"/data/images/10-13097A.jpg"
+    "image":"data/images/10-13097B.jpg",
+    "largeImage":"data/images/10-13097A.jpg"
   },
   {
     "name":"G+Logo+White+T-Shirt",
@@ -302,8 +302,8 @@
     "category":"mens_tshirts",
     "price":13,
     "description":"There's a new G in town and it's here to stay. Get your hands on this comfy white tee featuring the new Google icon.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% combed, ringspun cotton.&lt;/li&gt;&lt;li&gt;Side-seamed.&lt;/li&gt;&lt;li&gt;Unisex size, retail fit by Bella+Canvas.&lt;/li&gt;&lt;li&gt;Available in white with the Google 'G' icon screenprinted at front.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13275B.jpg",
-    "largeImage":"/data/images/10-13275A.jpg"
+    "image":"data/images/10-13275B.jpg",
+    "largeImage":"data/images/10-13275A.jpg"
   },
   {
     "name":"Android+Concert+T-Shirt",
@@ -311,8 +311,8 @@
     "category":"mens_tshirts",
     "price":13.65,
     "description":"Back by popular demand! Rock out with this Android Concert t-shirt.&amp;nbsp; &lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% combed cotton.&lt;/li&gt;&lt;li&gt;Made in the USA.&lt;/li&gt;&lt;li&gt;Available in grey with the Android screen printed in orange at center chest.&amp;nbsp;&lt;/li&gt;&lt;li&gt;&lt;b&gt;Sizing runs smaller than normal. Please reference size chart before ordering.&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13130B.jpg",
-    "largeImage":"/data/images/10-13130A.jpg"
+    "image":"data/images/10-13130B.jpg",
+    "largeImage":"data/images/10-13130A.jpg"
   },
   {
     "name":"Men+s+Bamboo+T-Shirt",
@@ -320,8 +320,8 @@
     "category":"mens_tshirts",
     "price":20.65,
     "description":"'Seriously soft' is one phrase we're not afraid to throw around when it comes to these bamboo tees.&amp;nbsp;Made with 70% viscose from organic bamboo and 30% organic cotton, your skin will thank you during those long nights of programming.&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;&amp;nbsp;Available in blue with the Google logo screen printed in white across center chest.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13269B.jpg",
-    "largeImage":"/data/images/10-13269A.jpg"
+    "image":"data/images/10-13269B.jpg",
+    "largeImage":"data/images/10-13269A.jpg"
   },
   {
     "name":"Android+Pay+Crew+Neck+T-Shirt",
@@ -329,8 +329,8 @@
     "category":"mens_tshirts",
     "price":19.4,
     "description":"Wear. Wash. Repeat. This tee celebrates the most exciting way to pay for life's necessities. For more information on Android Pay, visit our site here; https://www.android.com/pay/.&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;60/40 cotton/polyester blend.&lt;/li&gt;&lt;li&gt;Tagless label for added comfort.&lt;/li&gt;&lt;li&gt;Made in the USA.&lt;/li&gt;&lt;li&gt;Available in Pepper Black with the Android Pay icon screenprinted at front chest and Android Pay logo text at left sleeve.&lt;/li&gt;&lt;/ul&gt;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13263B.jpg",
-    "largeImage":"/data/images/10-13263A.jpg"
+    "image":"data/images/10-13263B.jpg",
+    "largeImage":"data/images/10-13263A.jpg"
   },
   {
     "name":"Google+Maps+T-Shirt",
@@ -338,8 +338,8 @@
     "category":"mens_tshirts",
     "price":18.35,
     "description":"Make a geographical statement with this royal blue American Apparel tee.&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% combed cotton.&lt;/li&gt;&lt;li&gt;Available in royal with the Google Maps pin and \"I am here\" text on the front, Google Maps logo on the back, and URL on the sleeve.&amp;nbsp;&lt;/li&gt;&lt;li&gt;&lt;b&gt;Sizes run smaller than normal. Please reference size chart before ordering.&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13277B.jpg",
-    "largeImage":"/data/images/10-13277A.jpg"
+    "image":"data/images/10-13277B.jpg",
+    "largeImage":"data/images/10-13277A.jpg"
   },
   {
     "name":"Est.+98+Baseball+Tee",
@@ -347,8 +347,8 @@
     "category":"mens_tshirts",
     "price":17.9,
     "description":"Hit a home run in the style stakes with this classic baseball tee. Designed with traditional contrast sleeves and an 'est 98' graphic honoring the year Google was founded.&amp;nbsp;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;Unisex fit.&lt;/li&gt;&lt;li&gt;52% cotton, 48% polyester.&lt;/li&gt;&lt;li&gt;Available in white with black sleeves and the white Google logo printed at left bicep.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13290B.jpg",
-    "largeImage":"/data/images/10-13290A.jpg"
+    "image":"data/images/10-13290B.jpg",
+    "largeImage":"data/images/10-13290A.jpg"
   },
   {
     "name":"Mountain+View+T-Shirt",
@@ -356,7 +356,7 @@
     "category":"mens_tshirts",
     "price":16.5,
     "description":"The Bay Area city named for its beautiful views of the Santa Cruz Mountains is also home to the Googleplex located at 1600 Amphitheater Parkway. Celebrate the place Google calls home in this American Apparel tee.&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Features:&lt;/div&gt;&lt;div&gt;&lt;ul&gt;&lt;li&gt;100% combed cotton.&lt;/li&gt;&lt;li&gt;Made in Los Angeles.&lt;/li&gt;&lt;li&gt;Available in white with the Mountain View coordinates screenprinted at front and the full color Google logo screenprinted at back yoke.&lt;/li&gt;&lt;/ul&gt;&lt;/div&gt;",
-    "image":"/data/images/10-13288B.jpg",
-    "largeImage":"/data/images/10-13288A.jpg"
+    "image":"data/images/10-13288B.jpg",
+    "largeImage":"data/images/10-13288A.jpg"
   }
 ]

--- a/index.html
+++ b/index.html
@@ -12,17 +12,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <base href="/">
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
   <title>SHOP</title>
 
-  <link rel="shortcut icon" sizes="32x32" href="/images/shop-icon-32.png">
+  <link rel="shortcut icon" sizes="32x32" href="images/shop-icon-32.png">
 
   <meta name="theme-color" content="#fff">
-  <link rel="manifest" href="/manifest.json">
+  <link rel="manifest" href="manifest.json">
 
-  <script src="/bower_components/webcomponentsjs/webcomponents-loader.js"></script>
-  <link rel="import" href="/src/shop-app.html">
+  <script src="bower_components/webcomponentsjs/webcomponents-loader.js"></script>
+  <link rel="import" href="src/shop-app.html">
 
   <style>
 

--- a/src/shop-app.html
+++ b/src/shop-app.html
@@ -441,7 +441,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             Polymer.importHref(this.resolveUrl('lazy-resources.html'), () => {
               // Register service worker if supported.
               if ('serviceWorker' in navigator) {
-                navigator.serviceWorker.register('/service-worker.js');
+                navigator.serviceWorker.register('service-worker.js', {scope: '/'});
               }
               this._notifyNetworkStatus();
               this.loadComplete = true;

--- a/src/shop-category-data.html
+++ b/src/shop-category-data.html
@@ -18,25 +18,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       {
         name: 'mens_outerwear',
         title: 'Men\'s Outerwear',
-        image: '/images/mens_outerwear.jpg',
+        image: 'images/mens_outerwear.jpg',
         placeholder: 'data:image/jpeg;base64,/9j/4QAYRXhpZgAASUkqAAgAAAAAAAAAAAAAAP/sABFEdWNreQABAAQAAAAeAAD/7gAOQWRvYmUAZMAAAAAB/9sAhAAQCwsLDAsQDAwQFw8NDxcbFBAQFBsfFxcXFxcfHhcaGhoaFx4eIyUnJSMeLy8zMy8vQEBAQEBAQEBAQEBAQEBAAREPDxETERUSEhUUERQRFBoUFhYUGiYaGhwaGiYwIx4eHh4jMCsuJycnLis1NTAwNTVAQD9AQEBAQEBAQEBAQED/wAARCAADAA4DASIAAhEBAxEB/8QAXAABAQEAAAAAAAAAAAAAAAAAAAIEAQEAAAAAAAAAAAAAAAAAAAACEAAAAwYHAQAAAAAAAAAAAAAAERMBAhIyYhQhkaEDIwUVNREBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8A3dkr5e8tfpwuneJITOzIcmQpit037Bw4mnCVNOpAAQv/2Q=='
       },
       {
         name: 'ladies_outerwear',
         title: 'Ladies Outerwear',
-        image: '/images/ladies_outerwear.jpg',
+        image: 'images/ladies_outerwear.jpg',
         placeholder: 'data:image/jpeg;base64,/9j/4QAYRXhpZgAASUkqAAgAAAAAAAAAAAAAAP/sABFEdWNreQABAAQAAAAeAAD/7gAOQWRvYmUAZMAAAAAB/9sAhAAQCwsLDAsQDAwQFw8NDxcbFBAQFBsfFxcXFxcfHhcaGhoaFx4eIyUnJSMeLy8zMy8vQEBAQEBAQEBAQEBAQEBAAREPDxETERUSEhUUERQRFBoUFhYUGiYaGhwaGiYwIx4eHh4jMCsuJycnLis1NTAwNTVAQD9AQEBAQEBAQEBAQED/wAARCAADAA4DASIAAhEBAxEB/8QAWQABAQAAAAAAAAAAAAAAAAAAAAEBAQEAAAAAAAAAAAAAAAAAAAIDEAABAwMFAQAAAAAAAAAAAAARAAEygRIDIlITMwUVEQEBAAAAAAAAAAAAAAAAAAAAQf/aAAwDAQACEQMRAD8Avqn5meQ0kwk1UyclmLtNj7L4PQoioFf/2Q=='
       },
       {
         name: 'mens_tshirts',
         title: 'Men\'s T-Shirts',
-        image: '/images/mens_tshirts.jpg',
+        image: 'images/mens_tshirts.jpg',
         placeholder: 'data:image/jpeg;base64,/9j/4QAYRXhpZgAASUkqAAgAAAAAAAAAAAAAAP/sABFEdWNreQABAAQAAAAeAAD/7gAOQWRvYmUAZMAAAAAB/9sAhAAQCwsLDAsQDAwQFw8NDxcbFBAQFBsfFxcXFxcfHhcaGhoaFx4eIyUnJSMeLy8zMy8vQEBAQEBAQEBAQEBAQEBAAREPDxETERUSEhUUERQRFBoUFhYUGiYaGhwaGiYwIx4eHh4jMCsuJycnLis1NTAwNTVAQD9AQEBAQEBAQEBAQED/wAARCAADAA4DASIAAhEBAxEB/8QAWwABAQEAAAAAAAAAAAAAAAAAAAMEAQEAAAAAAAAAAAAAAAAAAAAAEAABAwEJAAAAAAAAAAAAAAARAAESEyFhodEygjMUBREAAwAAAAAAAAAAAAAAAAAAAEFC/9oADAMBAAIRAxEAPwDb7kupZU1MTGnvOCgxpvzEXTyRElCmf//Z'
       },
       {
         name: 'ladies_tshirts',
         title: 'Ladies T-Shirts',
-        image: '/images/ladies_tshirts.jpg',
+        image: 'images/ladies_tshirts.jpg',
         placeholder: 'data:image/jpeg;base64,/9j/4QAYRXhpZgAASUkqAAgAAAAAAAAAAAAAAP/sABFEdWNreQABAAQAAAAeAAD/7gAOQWRvYmUAZMAAAAAB/9sAhAAQCwsLDAsQDAwQFw8NDxcbFBAQFBsfFxcXFxcfHhcaGhoaFx4eIyUnJSMeLy8zMy8vQEBAQEBAQEBAQEBAQEBAAREPDxETERUSEhUUERQRFBoUFhYUGiYaGhwaGiYwIx4eHh4jMCsuJycnLis1NTAwNTVAQD9AQEBAQEBAQEBAQED/wAARCAADAA4DASIAAhEBAxEB/8QAXwABAQEAAAAAAAAAAAAAAAAAAAMFAQEBAAAAAAAAAAAAAAAAAAABAhAAAQIDCQAAAAAAAAAAAAAAEQABITETYZECEjJCAzMVEQACAwAAAAAAAAAAAAAAAAAAATFBgf/aAAwDAQACEQMRAD8AzeADAZiFc5J7BC9Scek3VrtooilSNaf/2Q=='
       }
     ];
@@ -113,7 +113,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           return;
         }
         this._getResource({
-          url: '/data/' + category.name + '.json',
+          url: 'data/' + category.name + '.json',
           onLoad(e) {
             this.set('category.items', JSON.parse(e.target.responseText));
           },

--- a/src/shop-checkout.html
+++ b/src/shop-checkout.html
@@ -120,7 +120,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <iron-form id="checkoutForm"
               on-iron-form-response="_didReceiveResponse"
               on-iron-form-presubmit="_willSendRequest">
-            <form method="post" action="/data/sample_success_response.json">
+            <form method="post" action="data/sample_success_response.json">
 
               <div class="subsection" visible$="[[!_hasItems]]">
                 <p class="empty-cart">Your <iron-icon icon="shopping-cart"></iron-icon> is empty.</p>


### PR DESCRIPTION
We want to demonstrate differential serving using shop as an example where we serve a different build (e.g. bundled/unbundled) to different user agents based on their capabilities (e.g. push).

The strategy we have settled on (cc @graynorton) is to switch the entrypoint we serve depending on user agent, where each entrypoint has a `<base>` tag pointing to its build sub-directory, so that we can then use relative links to point at the right static resources.

So, this PR updates shop to use relative links for static resources, and adds a default `<base href="/">` tag (which we will automatically update from `polymer build`) so that the app behaves exactly as before when served from the root.

It also sets the service worker scope to `/` so that (in conjunction with a `Service-Worker-Allowed` header), service workers served from a build's sub-directory can intercept requests from all routes.