### PR TITLE
Fixes credit card number / cvc number validation issue

### DIFF
--- a/src/shop-checkout.js
+++ b/src/shop-checkout.js
@@ -292,7 +292,7 @@ class ShopCheckout extends PolymerElement {
                   </div>
                   <div class="row input-row">
                     <shop-input>
-                      <input type="tel" id="ccNumber" name="ccNumber" pattern="[\d\s]{15,}"
+                      <input type="tel" id="ccNumber" name="ccNumber" pattern="[\\d\\s]{15,}"
                           placeholder="Card Number" required
                           autocomplete="cc-number">
                       <shop-md-decorator error-message="Invalid Card Number" aria-hidden="true">
@@ -345,7 +345,7 @@ class ShopCheckout extends PolymerElement {
                       </shop-md-decorator>
                     </shop-select>
                     <shop-input>
-                      <input type="tel" id="ccCVV" name="ccCVV" pattern="\d{3,4}"
+                      <input type="tel" id="ccCVV" name="ccCVV" pattern="\\d{3,4}"
                           placeholder="CVV" required
                           autocomplete="cc-csc">
                       <shop-md-decorator error-message="Invalid CVV" aria-hidden="true">


### PR DESCRIPTION
In [https://shop.polymer-project.org/checkout](https://shop.polymer-project.org/checkout) credit card number field and CVC number field fails to validate the number. This is due to backslash in `input[pattern]` attribute within template literal being eliminated when rendered.

This patch makes those backslashes doubled so they will be rendered properly.